### PR TITLE
[WIP] Add other (x264, x265) encoding options

### DIFF
--- a/src/encoder/codecs.js
+++ b/src/encoder/codecs.js
@@ -108,6 +108,7 @@ export default class extends React.PureComponent {
             >
               <MenuItem value="vp9" primaryText="vp9" />
               <MenuItem value="vp8" primaryText="vp8" />
+              <MenuItem value="x264" primaryText="x264" />
             </SmallSelect>
             <Sep/>
             <SmallInput
@@ -192,6 +193,28 @@ export default class extends React.PureComponent {
               </SmallSelect>
             </ShowHide>
           </Prop>
+          <ShowHide show={this.props.vcodec === "x264"}>
+            <Prop name="preset" valueClassName={classes.valueCheck}>
+              <SmallSelect
+                width={100}
+                title="Preset mode"
+                value={this.props.preset}
+                disabled={this.props.encoding}
+                onChange={this.props.makeSelecter("preset")}
+              >
+                <MenuItem value="ultrafast" primaryText="ultrafast" />
+                <MenuItem value="superfast" primaryText="superfast" />
+                <MenuItem value="veryfast" primaryText="veryfast" />
+                <MenuItem value="faster" primaryText="faster" />
+                <MenuItem value="fast" primaryText="fast" />
+                <MenuItem value="medium" primaryText="medium" />
+                <MenuItem value="slow" primaryText="slow" />
+                <MenuItem value="slower" primaryText="slower" />
+                <MenuItem value="veryslow" primaryText="veryslow" />
+                <MenuItem value="placebo" primaryText="placebo" />
+              </SmallSelect>
+            </Prop>
+          </ShowHide>
         </HelpPane>
         <Prop name="raw args" nameClassName={classes.nameArgs}>
           <ArgsInput

--- a/src/encoder/encode.js
+++ b/src/encoder/encode.js
@@ -143,6 +143,9 @@ export default class extends React.PureComponent {
     this.tmpPreviewName = tmp.tmpNameSync({prefix: "boram-", postfix: ".webm"});
     this.tmpConcatName = tmp.tmpNameSync({prefix: "boram-", postfix: ".txt"});
   }
+  componentDidUpdate(prevProps) {
+    if (this.props.vcodec !== prevProps.vcodec) this.updateTarget();
+  }
   componentWillUnmount() {
     this.props.events.removeListener("abort", this.abort);
     this.cleanup();
@@ -388,9 +391,10 @@ export default class extends React.PureComponent {
     bareName = bareName.replace(/-\d+$/, "");
     let index = 0;
     let target = "";
+    const fileFormat = (this.props.vcodec === "x264") ? "mp4" : "webm";
     do {
       const suffix = `-${index + 1}`;
-      const name = `${bareName}${index ? suffix : ""}.webm`;
+      const name = `${bareName}${index ? suffix : ""}.${fileFormat}`;
       target = path.join(dir, name);
       index += 1;
     } while (fs.existsSync(target));
@@ -492,6 +496,7 @@ export default class extends React.PureComponent {
       defaultPath: this.state.target,
       filters: [
         {name: "WebM", extensions: ["webm"]},
+        {name: "x264", extensions: ["mp4"]},
       ],
     });
     if (!target) return;


### PR DESCRIPTION
This app is really a handy tool for simple video editing.
VP8/9 are good encoder but x264/x265 have better compatibility. So an option providing those would be convenient when needed, like, in Telegram.
I tried adding them in my fork and it works, but this PR is still a WIP actually.
Because boram's description writes "Cross-platform WebM converter", I'm kindly asking if you can accept more encoding options (besides WebM) to be added in boram. I'd try finishing this PR if you would accept it.