### PR TITLE
Try to fix cropping border

### DIFF
--- a/src/player/index.js
+++ b/src/player/index.js
@@ -565,8 +565,8 @@ class CropArea extends React.PureComponent {
       let {startW: width, startH: height, startX: left, startY: top} = this;
       switch (this.startPos) {
       case "nw":
-        left += dx;
-        width -= dx;
+        if (left !== 0) left += dx;
+        if (left !== 0) width -= dx;
         top += dy;
         height -= dy;
         break;
@@ -580,8 +580,8 @@ class CropArea extends React.PureComponent {
         height -= dy;
         break;
       case "sw":
-        left += dx;
-        width -= dx;
+        if (left !== 0) left += dx;
+        if (left !== 0) width -= dx;
         height += dy;
         break;
       case "n":
@@ -595,8 +595,8 @@ class CropArea extends React.PureComponent {
         width += dx;
         break;
       case "w":
-        left += dx;
-        width -= dx;
+        if (left !== 0) left += dx;
+        if (left !== 0) width -= dx;
         break;
       case "i":
         left += dx;

--- a/src/player/index.js
+++ b/src/player/index.js
@@ -565,8 +565,8 @@ class CropArea extends React.PureComponent {
       let {startW: width, startH: height, startX: left, startY: top} = this;
       switch (this.startPos) {
       case "nw":
-        if (left !== 0) left += dx;
-        if (left !== 0) width -= dx;
+        if (!(left === 0 && dx < 0)) left += dx;
+        if (!(left === 0 && dx < 0)) width -= dx;
         top += dy;
         height -= dy;
         break;
@@ -580,8 +580,8 @@ class CropArea extends React.PureComponent {
         height -= dy;
         break;
       case "sw":
-        if (left !== 0) left += dx;
-        if (left !== 0) width -= dx;
+        if (!(left === 0 && dx < 0)) left += dx;
+        if (!(left === 0 && dx < 0)) width -= dx;
         height += dy;
         break;
       case "n":
@@ -595,8 +595,8 @@ class CropArea extends React.PureComponent {
         width += dx;
         break;
       case "w":
-        if (left !== 0) left += dx;
-        if (left !== 0) width -= dx;
+        if (!(left === 0 && dx < 0)) left += dx;
+        if (!(left === 0 && dx < 0)) width -= dx;
         break;
       case "i":
         left += dx;


### PR DESCRIPTION
![2018-08-09 17_31_23](https://user-images.githubusercontent.com/1764123/43890736-18220c16-9bfa-11e8-9add-b52b6b305ccc.gif)

When `left` equals to zero, dragging the left side of the cropping border to the left should not increase `width`. This PR try to fix it dirtily.

When `left` > 0, dragging left border to the left through the bound of the video still makes width increase. Can't solve it yet :(