### PR TITLE
Replace legacy Youtube-dl with currently maintained yt-dlp

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * Open-source, cross-platform, works on Windows, Mac and Linux
 * AV1/VP9/VP8/Opus/Vorbis/2pass/limit/CRF/CQ/raw-args modes support
 * Industry-grade codec settings, considered defaults
-* Can download source from almost any streaming site, thanks to [youtube-dl](https://rg3.github.io/youtube-dl/)
+* Can download source from almost any streaming site, thanks to [yt-dlp](https://github.com/yt-dlp/yt-dlp)
 * Displays almost any video with embedded player, thanks to [mpv](https://mpv.io/)
 * Hardsubbing out of the box with proper shift/track selection
 * Simple yet powerful interface, source video centric design
@@ -35,7 +35,7 @@ boram's own code is licensed under [CC0](licenses/LICENSE.BORAM) but releases al
 
 * Libraries from dependencies section of [package.json](package.json)
 * [Chromium](licenses/LICENSE.CHROMIUM) and [Electron](licenses/LICENSE.ELECTRON) components
-* [youtube-dl binaries](licenses/LICENSE.PYTHON)
+* [yt-dlp binaries](licenses/LICENSE.PYTHON)
 * [FFmpeg binaries](licenses/LICENSE.FFMPEG)
 * [mpv binaries](licenses/LICENSE.MPV)
 * [Font Awesome font](licenses/LICENSE.FONTAWESOME)

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "release-mac64": "rm -rf dist/*darwin-x64* && BORAM_PLATFORM=mac64 npm run app && npm run mpv-mac64 && chmod +x dist/app/{*.dylib,ffmpeg,ffprobe} && npm run pack-mac64",
     "release-lin64": "rm -rf dist/*linux-x64* && BORAM_PLATFORM=lin64 npm run app && npm run mpv-lin64 && npm run pack-lin64",
     "release": "rm -rf dist && npm run release-win32 && npm run release-win64 && npm run release-mac64 && npm run release-lin64",
-    "bin": "rm -rf bin && mkdir bin && cd bin && wget https://yt-dl.org/latest/youtube-dl -O youtube-dl.zip && wget https://yt-dl.org/latest/youtube-dl.exe && cp -a \"${BORAM_WIN_PREBUILT_ROOT}/local32\" win32 && cp -a \"${BORAM_WIN_PREBUILT_ROOT}/local64\" win64 && cp -a \"${BORAM_MAC_PREBUILT_ROOT}/deps\" mac64"
+    "bin": "rm -rf bin && mkdir bin && cd bin && wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -O yt-dlp.zip && wget https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe && cp -a \"${BORAM_WIN_PREBUILT_ROOT}/local32\" win32 && cp -a \"${BORAM_WIN_PREBUILT_ROOT}/local64\" win64 && cp -a \"${BORAM_MAC_PREBUILT_ROOT}/deps\" mac64"
   },
   "babel": {
     "plugins": [

--- a/scripts/make-mac64-deps.sh
+++ b/scripts/make-mac64-deps.sh
@@ -10,7 +10,7 @@ brew install libvpx --HEAD  # highbitdepth
 brew install aom --HEAD  # lowbitdepth
 brew install dav1d --HEAD
 brew install ffmpeg --HEAD --with-libass --with-aom --with-dav1d  # Without lame, sdl2, snappy, theora, x265, xvid, xz
-brew install mpv -s  # Without jpeg, little-cms2, lua, mujs, youtube-dl
+brew install mpv -s  # Without jpeg, little-cms2, lua, mujs, yt-dlp
 
 DEPS="
 /usr/local/bin/ffmpeg

--- a/src/index/deps.js
+++ b/src/index/deps.js
@@ -35,8 +35,8 @@ export function checkLinuxDeps() {
   if (!hasBinary("ffprobe")) {
     throw new Error("ffprobe not found");
   }
-  if (!hasBinary("youtube-dl") && !hasBinary("python")) {
-    throw new Error("youtube-dl/python not found");
+  if (!hasBinary("yt-dlp") && !hasBinary("python")) {
+    throw new Error("yt-dlp/python not found");
   }
   if (!hasLibrary("libmpv.so.1") && !hasLibrary("libmpv.so")) {
     throw new Error("libmpv not found");

--- a/src/source/download.js
+++ b/src/source/download.js
@@ -1,5 +1,5 @@
 /**
- * Download source video with youtube-dl.
+ * Download source video with yt-dlp.
  * @module boram/source/download
  */
 
@@ -8,7 +8,7 @@ import {remote} from "electron";
 import tmp from "tmp";
 import React from "react";
 import cx from "classnames";
-import YouTubeDL from "../youtube-dl";
+import YouTubeDL from "../yt-dlp";
 import {useSheet} from "../jss";
 import {BigProgress, BigButton, Sep} from "../theme";
 import {showErr} from "../util";
@@ -48,7 +48,7 @@ export default class extends React.PureComponent {
     this.props.events.removeListener("abort", this.abort);
   }
   handleDownload = () => {
-    this.setState({progress: 0, status: "spawning youtube-dl", error: null});
+    this.setState({progress: 0, status: "spawning yt-dlp", error: null});
     this.props.onProgress(0);
     const {info, format} = this.props;
     const url = info.webpage_url;

--- a/src/source/format.js
+++ b/src/source/format.js
@@ -117,7 +117,7 @@ export default class extends React.PureComponent {
   }
   getSubFormats() {
     // ytdl automatically selects format across available subtitles
-    // (e.g. it selects vtt across ttml and vtt on youtube). We hope
+    // (e.g. it selects vtt across ttml and vtt on yt-dlp). We hope
     // selected format is always appropriate because we can't
     // distinguish multiple formats with same ID.
     const requestedFormats = this.props.info.requested_subtitles || {};

--- a/src/source/source.js
+++ b/src/source/source.js
@@ -7,12 +7,12 @@ import {shell, remote} from "electron";
 import React from "react";
 import cx from "classnames";
 import {useSheet} from "../jss";
-import YouTubeDL from "../youtube-dl";
+import YouTubeDL from "../yt-dlp";
 import {Icon, Tip} from "../theme";
 import {showErr} from "../util";
 
 const YTDL_SUPPORTED_URL =
-  "https://rg3.github.io/youtube-dl/supportedsites.html";
+  "https://github.com/yt-dlp/yt-dlp/blob/master/supportedsites.md";
 const COMMON_VIDEO_EXTENSIONS = [
   "mkv", "webm",
   "ogg", "ogv", "ogm",
@@ -195,7 +195,7 @@ export default class extends React.PureComponent {
           <span>Any site </span>
           <a href="" onClick={this.handleSupportedClick}
              title="Open list in browser">
-            supported by youtube-dl
+            supported by yt-dlp
           </a>
           <span> is accepted</span>
         </Tip>

--- a/src/youtube-dl/index.js
+++ b/src/youtube-dl/index.js
@@ -1,25 +1,25 @@
 /**
- * youtube-dl wrapper. Provides platform-independent Promise API.
- * @module boram/youtube-dl
+ * yt-dlp wrapper. Provides platform-independent Promise API.
+ * @module boram/yt-dlp
  */
 
 import assert from "assert";
 import path from "path";
 import {APP_PATH} from "../shared";
 import {makeRunner, getRunPath} from "../util";
-require("../../bin/youtube-dl." + (BORAM_WIN_BUILD ? "exe" : "zip"));
+require("../../bin/yt-dlp." + (BORAM_WIN_BUILD ? "exe" : "zip"));
 
-export default makeRunner("youtube-dl", {
+export default makeRunner("yt-dlp", {
   _fixPathArgs(runpath, args) {
     // Special case for ytdl on Mac: we run it with python.
     if (BORAM_MAC_BUILD || !runpath) {
-      // We always pack youtube-dl binary on Windows.
+      // We always pack yt-dlp binary on Windows.
       assert(!BORAM_WIN_BUILD);
       // Can be run as executable but this way we get better error
       // message if Python is not installed.
       const altexe = "python";
       runpath = getRunPath(altexe, {system: true});
-      const zippath = path.join(APP_PATH, "youtube-dl.zip");
+      const zippath = path.join(APP_PATH, "yt-dlp.zip");
       return [runpath, [zippath].concat(args), altexe];
     } else {
       return [runpath, args];


### PR DESCRIPTION
Replacing the included youtube-dl.exe with a renamed yt-dlp.exe made everything work as expected again and download fast. Based on this, this PR should fix the issue across all platforms with minimal changes, mostly comsetic (youtube-dl -> yt-dlp).

I modified the package stuff to include these as well, although I'm not sure why the python script is saved as a .zip. I also checked and there is a brew package for yt-dlp, so I swapped that as well.

Should fix #67 and #61, although I don't have a build environment set up for this to test it.
